### PR TITLE
Use new categories for segments

### DIFF
--- a/preprocessing_geographic.py
+++ b/preprocessing_geographic.py
@@ -20,9 +20,15 @@ def main(railroads, distance, out_nodes, out_segments):
     gs.run_command(
         "v.build.polylines",
         input=railroads,
-        output=railroads + "_simplified",
-        cats="first",
+        output=railroads + "_poly",
+        cats="no",
         type="line",
+    )
+    gs.run_command(
+        "v.category",
+        input=railroads + "_poly",
+        output=railroads + "_simplified",
+        option="add",
     )
     gs.run_command(
         "v.to.points",


### PR DESCRIPTION
Drop the existing categories and create new categories (ids) for the segments.
This avoids putting two unrelated, disconnected lines into same segment when
they have the same category in the input.
